### PR TITLE
Username mapping

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -13,3 +13,9 @@ ldap_group_filter: (objectClass=posixGroup)
 # These can be better explained at https://github.com/fullcontact/hesiod53/blob/master/example_users.yml
 hesiod_domain: {subdomain}.{yourdomain}.com
 route53_zone: {subdomain}.{yourdomain}.com
+
+# if the username in jumpcloud does not match the desired unix username, then
+# this map will change the usernames and home directories as appropriate
+# this block is optional
+username_map:
+  jumpcloud_username: mapped_username

--- a/jumpcloud/jumpcloud.py
+++ b/jumpcloud/jumpcloud.py
@@ -68,6 +68,17 @@ class Parser(object):
                 return True
         return False
 
+# modifies usernames of the users using the username_map
+# if a username is not in the map, then the username is not modified
+def map_usernames(users, username_map):
+    for user in users:
+        username = user['username']
+        if username in username_map:
+            mapped_username = username_map[username]
+            # homedir is optional, username is not
+            user['username'] = mapped_username
+            if "homedir" in user:
+                user['homedir'] = user['homedir'].replace(username, mapped_username)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -104,6 +115,9 @@ def main():
     parser = Parser(config)
     hesiod['users'] = parser.parse_all_users(groups, jumpcloud_users)
     hesiod['groups'] = parser.parse_all_groups(groups)
+
+    if "username_map" in config:
+        map_usernames(hesiod["users"], config["username_map"])
 
     print yaml.dump(hesiod)
 


### PR DESCRIPTION
If a Jumpcloud username does not match the desired UNIX username, modify the username and home directory using an optional mapping function defined in the configuration.

This way I can be bvargo again. :)

There is minimal testing, since I don't have LDAP access, but I tested using an offline user file.

@riltsken
